### PR TITLE
책 삭제할때 책에 딸려있는 즐겨찾기,리뷰 같이삭제

### DIFF
--- a/src/view/EditableBookInfo.java
+++ b/src/view/EditableBookInfo.java
@@ -137,7 +137,7 @@ public class EditableBookInfo extends JFrame {
 			@Override
 			public void mouseClicked(MouseEvent e) {
 
-				String sql = "UPDATE BOOK\r\n"
+				String sql1 = "UPDATE BOOK\r\n"
 						+ "SET BOOK_PRE = FALSE\r\n"
 						+ "WHERE BOOK_ISBN = ?;";
 				
@@ -151,17 +151,32 @@ public class EditableBookInfo extends JFrame {
 						JOptionPane.showMessageDialog(null, "대여중인 도서입니다.", "도서 삭제 실패",
 								JOptionPane.ERROR_MESSAGE);
 					} else {
-						PreparedStatement ps = dbConn.conn.prepareStatement(sql);
+						PreparedStatement ps1 = dbConn.conn.prepareStatement(sql1);
 
-						ps.setString(1, book_ISBN);	//도서 PK
+						ps1.setString(1, book_ISBN);	//도서 PK
 						
-						int count = ps.executeUpdate();
-						if (count == 0) {
+						int count1 = ps1.executeUpdate();
+						
+						//즐겨찾기 삭제
+						String sql2="DELETE from FAVORITES\r\n"
+								+ "WHERE FAVORITES.BOOK_ISBN = '"+book_ISBN+"';";
+						PreparedStatement ps2 = dbConn.conn.prepareStatement(sql2);
+						int count2 = ps2.executeUpdate();
+						
+						//리뷰 삭제
+						String sql3="DELETE from REVIEW\r\n"
+								+ "WHERE REVIEW.BOOK_ISBN = '"+book_ISBN+"';";
+						PreparedStatement ps3=dbConn.conn.prepareStatement(sql3);
+						int count3 = ps3.executeUpdate();
+						
+						if (count1 == 0||count2==0||count3==0) {
 							JOptionPane.showMessageDialog(null, "도서 삭제에 실패하였습니다.", "도서 삭제 실패",
 									JOptionPane.ERROR_MESSAGE);
 						} else {
 							JOptionPane.showMessageDialog(null, "도서 삭제에 성공하였습니다.", "도서 삭제 성공",
 									JOptionPane.NO_OPTION);
+							
+
 						}
 					}
 				} catch (SQLException e1) {


### PR DESCRIPTION
## 책 삭제할때 책에 딸려있는 즐겨찾기,리뷰 같이삭제
그냥 책 삭제했을때, 만약 즐겨찾기가 되어있으면 유저창에 아무 정보도 없지만, 그 삭제된 책의 리뷰가 있는 책이 뜸. 그리고 없는책이지만 리뷰와 대출반납이 가능함.
이런 이유로 책 삭제때, 즐겨찾기와 리뷰를 같이 삭제하도록 수정